### PR TITLE
Added check for window sizes on resizing

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -181,7 +181,6 @@ impl Context {
                 if w == 0 || h == 0 {
                     return
                 }
-
                 self.win_size = Size2{w: w as i32, h: h as i32};
                 gfx_glutin::update_views(
                     &self.window,

--- a/src/context.rs
+++ b/src/context.rs
@@ -178,6 +178,10 @@ impl Context {
                 self.mouse.is_right_button_pressed = false;
             },
             Event::Resized(w, h) => {
+                if w == 0 || h == 0 {
+                    return
+                }
+
                 self.win_size = Size2{w: w as i32, h: h as i32};
                 gfx_glutin::update_views(
                     &self.window,


### PR DESCRIPTION
Do not update view when window width/height is 0, then window will not crash on Windows systems