### PR TITLE
Add sleep to main thread to reduce excess load

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,26 @@ mod mesh;
 mod fs;
 
 use std::env;
+use std::thread;
+use std::time as stdtime;
 use visualizer::{Visualizer};
+
+const MAX_FPS: u64 = 60;
 
 pub fn main() {
     env::set_var("RUST_BACKTRACE", "1");
     let mut visualizer = Visualizer::new();
+
+    let max_frame_time = stdtime::Duration::from_millis(1000 / MAX_FPS);
+
     while visualizer.is_running() {
+        let start = stdtime::Instant::now();
         visualizer.tick();
+
+        let delta = start.elapsed();
+        if max_frame_time > delta {
+            println!("Sleeping for: {:?}", max_frame_time - delta);
+            thread::sleep(max_frame_time - delta);
+        }
     }
 }


### PR DESCRIPTION
- lock to a specific FPS

Fix for #235, and I used `std::time` as per #234. I'm not sure if you'd prefer this to happen within `Visualizer` or have it be more intelligent (e.g. skip drawing, but still listen for events if the last computation took too long).

This change makes my computer whine less :)