### PR TITLE
Add hover to gui + minimal start of making gui more flexible

### DIFF
--- a/src/context_menu_popup.rs
+++ b/src/context_menu_popup.rs
@@ -10,7 +10,7 @@ use core::check::{check_command};
 use types::{Time, ScreenPos};
 use screen::{Screen, ScreenCommand, EventStatus};
 use context::{Context};
-use gui::{ButtonManager, Button, ButtonId, is_tap, basic_text_size};
+use gui::{ButtonManager, Button, GuiId, Widget, is_tap, basic_text_size};
 use player_info::{PlayerInfo};
 use reinforcements_popup;
 
@@ -254,18 +254,18 @@ pub struct ContextMenuPopup {
     game_screen_tx: Sender<Command>,
     button_manager: ButtonManager,
     options: Options,
-    select_button_ids: HashMap<ButtonId, UnitId>,
-    attack_button_ids: HashMap<ButtonId, UnitId>,
-    load_button_ids: HashMap<ButtonId, UnitId>,
-    attach_button_ids: HashMap<ButtonId, UnitId>,
-    move_button_id: Option<ButtonId>,
-    hunt_button_id: Option<ButtonId>,
-    unload_unit_button_id: Option<ButtonId>,
-    detach_button_id: Option<ButtonId>,
-    smoke_button_id: Option<ButtonId>,
-    enable_reaction_fire_button_id: Option<ButtonId>,
-    disable_reaction_fire_button_id: Option<ButtonId>,
-    call_reinforcements_button_id: Option<ButtonId>,
+    select_button_ids: HashMap<GuiId, UnitId>,
+    attack_button_ids: HashMap<GuiId, UnitId>,
+    load_button_ids: HashMap<GuiId, UnitId>,
+    attach_button_ids: HashMap<GuiId, UnitId>,
+    move_button_id: Option<GuiId>,
+    hunt_button_id: Option<GuiId>,
+    unload_unit_button_id: Option<GuiId>,
+    detach_button_id: Option<GuiId>,
+    smoke_button_id: Option<GuiId>,
+    enable_reaction_fire_button_id: Option<GuiId>,
+    disable_reaction_fire_button_id: Option<GuiId>,
+    call_reinforcements_button_id: Option<GuiId>,
 }
 
 impl ContextMenuPopup {
@@ -414,7 +414,7 @@ impl ContextMenuPopup {
     fn handle_event_button_press(
         &mut self,
         context: &mut Context,
-        button_id: ButtonId
+        button_id: GuiId
     ) {
         if let Some(&unit_id) = self.select_button_ids.get(&button_id) {
             self.return_command(context, Command::Select {

--- a/src/game_results_screen.rs
+++ b/src/game_results_screen.rs
@@ -5,7 +5,7 @@ use core::{PlayerId, Score};
 use core::game_state::{State};
 use screen::{Screen, ScreenCommand, EventStatus};
 use context::{Context};
-use gui::{ButtonManager, Button, is_tap};
+use gui::{ButtonManager, Button, Widget, is_tap};
 use types::{ScreenPos, Time};
 
 fn winner_id(state: &State) -> PlayerId {

--- a/src/main_menu_screen.rs
+++ b/src/main_menu_screen.rs
@@ -5,14 +5,14 @@ use screen::{Screen, ScreenCommand, EventStatus};
 use tactical_screen::{TacticalScreen};
 use core;
 use context::{Context};
-use gui::{ButtonManager, Button, ButtonId, is_tap};
+use gui::{ButtonManager, Button, GuiId, Widget, is_tap};
 use types::{ScreenPos, Time};
 
 #[derive(Clone, Debug)]
 pub struct MainMenuScreen {
-    button_start_hotseat_id: ButtonId,
-    button_start_vs_ai_id: ButtonId,
-    button_map_id: ButtonId,
+    button_start_hotseat_id: GuiId,
+    button_start_vs_ai_id: GuiId,
+    button_map_id: GuiId,
     button_manager: ButtonManager,
     map_names: Vec<&'static str>,
     selected_map_index: usize,
@@ -74,7 +74,7 @@ impl MainMenuScreen {
     fn handle_event_button_press(
         &mut self,
         context: &mut Context,
-        button_id: ButtonId
+        button_id: GuiId
     ) {
         let map_name = self.map_names[self.selected_map_index].to_string();
         let mut core_options = core::Options {
@@ -121,7 +121,7 @@ impl MainMenuScreen {
 impl Screen for MainMenuScreen {
     fn tick(&mut self, context: &mut Context, _: Time) {
         context.clear();
-        context.set_basic_color([0.0, 0.0, 0.0, 1.0]);
+        context.set_basic_color([1.0, 1.0, 1.0, 1.0]);
         self.button_manager.draw(context);
     }
 

--- a/src/map_text.rs
+++ b/src/map_text.rs
@@ -72,7 +72,7 @@ impl MapTextManager {
             let mut to = from;
             to.v.z += 2.0;
             let mesh = {
-                let (size, texture_data) = text::text_to_texture(context.font(), 80.0, &command.text);
+                let (size, texture_data) = text::text_to_texture(context.font(), 80.0, &command.text, &[255,255,255,255]);
                 let texture = load_texture_raw(context.factory_mut(), size, &texture_data);
                 let scale_factor = 200.0; // TODO: take camera zoom into account
                 let h_2 = (size.h as f32 / scale_factor) / 2.0;

--- a/src/reinforcements_popup.rs
+++ b/src/reinforcements_popup.rs
@@ -9,7 +9,7 @@ use core::db::{Db};
 use types::{Time, ScreenPos};
 use screen::{Screen, ScreenCommand, EventStatus};
 use context::{Context};
-use gui::{ButtonManager, Button, ButtonId, is_tap, basic_text_size};
+use gui::{ButtonManager, Button, GuiId, is_tap, basic_text_size};
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Options {
@@ -55,7 +55,7 @@ pub fn get_options(
 pub struct ReinforcementsPopup {
     game_screen_tx: Sender<(UnitTypeId, ExactPos)>,
     button_manager: ButtonManager,
-    button_ids: HashMap<ButtonId, (UnitTypeId, ExactPos)>,
+    button_ids: HashMap<GuiId, (UnitTypeId, ExactPos)>,
 }
 
 impl ReinforcementsPopup {
@@ -102,7 +102,7 @@ impl ReinforcementsPopup {
     fn handle_event_button_press(
         &mut self,
         context: &mut Context,
-        button_id: ButtonId
+        button_id: GuiId
     ) {
         if let Some(&unit_info) = self.button_ids.get(&button_id) {
             self.game_screen_tx.send(unit_info).unwrap();

--- a/src/tactical_screen.rs
+++ b/src/tactical_screen.rs
@@ -11,7 +11,7 @@ use core::game_state::{State};
 use core::{self, CoreEvent, Command, UnitId, PlayerId, MapPos, ExactPos, SlotId, Object};
 use core::unit::{UnitTypeId};
 use core::misc::{opt_rx_collect};
-use gui::{ButtonManager, Button, ButtonId, is_tap};
+use gui::{ButtonManager, Button, GuiId, TextSize, is_tap, Widget};
 use scene::{Scene, NodeId, SceneNode};
 use event_visualizer;
 use unit_type_visual_info::{
@@ -79,23 +79,26 @@ fn wireframe_building_mesh_id(mesh_ids: &MeshIdManager, object: &Object) -> Mesh
 #[derive(Clone, Debug)]
 pub struct Gui {
     button_manager: ButtonManager,
-    button_end_turn_id: ButtonId,
-    button_deselect_unit_id: ButtonId,
-    button_next_unit_id: ButtonId,
-    button_prev_unit_id: ButtonId,
-    button_zoom_in_id: ButtonId,
-    button_zoom_out_id: ButtonId,
-    label_unit_info_id: Option<ButtonId>,
-    label_score_id: ButtonId,
-    label_reinforcement_points_id: ButtonId,
+    button_end_turn_id: GuiId,
+    button_deselect_unit_id: GuiId,
+    button_next_unit_id: GuiId,
+    button_prev_unit_id: GuiId,
+    button_zoom_in_id: GuiId,
+    button_zoom_out_id: GuiId,
+    label_unit_info_id: Option<GuiId>,
+    label_score_id: GuiId,
+    label_reinforcement_points_id: GuiId,
 }
 
 impl Gui {
     fn new(context: &mut Context, state: &State) -> Gui {
         let mut button_manager = ButtonManager::new();
         let mut pos = ScreenPos{v: Vector2{x: 10, y: 10}};
-        let button_end_turn_id = button_manager.add_button(
-            Button::new(context, "[end turn]", pos));
+        let mut b = Button::new2();
+        b.text("[end turn]")
+            .set_pos(pos)
+            .build(context);
+        let button_end_turn_id = button_manager.add_button(b);
         let ystep = (button_manager.buttons()[&button_end_turn_id].size().h as f32 * 1.2) as i32; // TODO
         pos.v.y += ystep;
         let button_deselect_unit_id = button_manager.add_button(
@@ -653,7 +656,7 @@ impl TacticalScreen {
         }
     }
 
-    fn handle_event_button_press(&mut self, context: &mut Context, button_id: ButtonId) {
+    fn handle_event_button_press(&mut self, context: &mut Context, button_id: GuiId) {
         if button_id == self.gui.button_end_turn_id {
             self.end_turn(context);
         } else if button_id == self.gui.button_deselect_unit_id {
@@ -728,7 +731,8 @@ impl TacticalScreen {
         self.draw_scene(context, dtime);
         let player_info = self.player_info.get(self.core.player_id());
         self.map_text_manager.draw(context, &player_info.camera, dtime);
-        context.set_basic_color([0.0, 0.0, 0.0, 1.0]);
+        // why is this set to black?
+        context.set_basic_color([1.0, 1.0, 1.0, 1.0]);
         self.gui.button_manager.draw(context);
     }
 
@@ -949,7 +953,7 @@ impl TacticalScreen {
 
     fn update_score_labels(&mut self, context: &mut Context) {
         let pos = self.gui.button_manager.buttons()[&self.gui.label_score_id].pos();
-        let label_score = Button::new_small(context, &score_text(self.current_state()), pos);
+        let label_score = Button::new(context, &score_text(self.current_state()), pos);
         self.gui.button_manager.remove_button(self.gui.label_score_id);
         self.gui.label_score_id = self.gui.button_manager.add_button(label_score);
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -5,7 +5,7 @@ fn calc_text_width(glyphs: &[PositionedGlyph]) -> f32 {
     glyphs.last().unwrap().pixel_bounding_box().unwrap().max.x as f32
 }
 
-pub fn text_to_texture(font: &Font, height: f32, text: &str) -> (Size2, Vec<u8>) {
+pub fn text_to_texture(font: &Font, height: f32, text: &str, rgba: &[u8; 4]) -> (Size2, Vec<u8>) {
     let scale = Scale { x: height, y: height };
     let v_metrics = font.v_metrics(scale);
     let offset = point(0.0, v_metrics.ascent);
@@ -13,7 +13,7 @@ pub fn text_to_texture(font: &Font, height: f32, text: &str) -> (Size2, Vec<u8>)
     let pixel_height = height.ceil() as usize;
     let width = calc_text_width(&glyphs) as usize;
     let mut pixel_data = vec![0_u8; 4 * width * pixel_height];
-    let mapping_scale = 255.0;
+    let mapping_scale = rgba[3] as f32;
     for g in glyphs {
         let bb = match g.pixel_bounding_box() {
             Some(bb) => bb,
@@ -26,9 +26,9 @@ pub fn text_to_texture(font: &Font, height: f32, text: &str) -> (Size2, Vec<u8>)
             // There's still a possibility that the glyph clips the boundaries of the bitmap
             if v > 0 && x >= 0 && x < width as i32 && y >= 0 && y < pixel_height as i32 {
                 let i = (x as usize + y as usize * width) * 4;
-                pixel_data[i] = 255;
-                pixel_data[i + 1] = 255;
-                pixel_data[i + 2] = 255;
+                pixel_data[i] = rgba[0];
+                pixel_data[i + 1] = rgba[1];
+                pixel_data[i + 2] = rgba[2];
                 pixel_data[i + 3] = v;
             }
         });


### PR DESCRIPTION
This is not meant to be pulled in, just a request for comments before making it nicer to see if the approach is okay in the first place. The full goal is to make it easy to add features to the gui such as adding new elements, adding styling, and supporting composition.

Things that need to be added/changed:
- Actually use builder pattern for things like Button (avoided as it's a lot of work wasted if you don't like the idea)
- Remove ButtonManager and replace it with a Panel class
- Add WidgetContainer trait to support composition. Panel would impl WidgetContainer for example. WidgetContainer would have add_widget fn and would require a Widget impl as well.
- Rename new2 (used to avoid immediate need to apply the new changes) to new and remove new_small in Button.